### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+target
+.git
+.gitignore
+Dockerfile
+*.env
+.env
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM rust:1.75-bullseye as builder
+WORKDIR /usr/src/multitts
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir src && echo 'fn main() {}' > src/main.rs
+RUN cargo build --release && rm -r src
+COPY . .
+RUN cargo build --release
+
+FROM debian:bullseye-slim
+RUN apt-get update && apt-get install -y ffmpeg ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/src/multitts/target/release/t /usr/local/bin/multitts
+WORKDIR /usr/src/multitts
+CMD ["/usr/local/bin/multitts"]

--- a/README.md
+++ b/README.md
@@ -27,3 +27,14 @@ Rust 製の Discord ボイスチャットボットです。
    `/join` を実行したチャンネルに投稿されたメッセージは自動的に読み上げられ、中国語のメッセージは中国語で、それ以外は日本語で読み上げます。
 
 TTS 機能として Google Translate の読み上げ音声を利用しています。
+
+## Docker での起動
+
+Docker でも実行できます。まずイメージをビルドします。
+```bash
+docker build -t multitts .
+```
+`.env` で利用する環境変数を設定した上で、次のように起動します。
+```bash
+docker run --env-file .env multitts
+```


### PR DESCRIPTION
## Summary
- create a Dockerfile for building and running the bot
- ignore development files in `.dockerignore`
- add instructions for Docker usage in the README

## Testing
- `cargo build` *(fails: failed to download crates index)*

------
https://chatgpt.com/codex/tasks/task_e_68407a99058883338de393516ade01bb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Docker support for the project, including a multi-stage Dockerfile and a `.dockerignore` file to optimize image builds.
- **Documentation**
  - Updated the README with instructions for building and running the application using Docker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->